### PR TITLE
STS-3034: FRS read/write functions

### DIFF
--- a/include/BNO085_SPI_Library.h
+++ b/include/BNO085_SPI_Library.h
@@ -93,6 +93,9 @@ uint8_t check_Command_Success(sensor_meta *sensor, uint8_t status_command);
 void deassert_csn(sensor_meta *sensor);
 uint8_t read_FRS(sensor_meta *sensor, uint16_t frs_type, uint32_t *buffer,
                  uint16_t max_words, uint16_t *words_read);
+uint8_t write_FRS(sensor_meta *sensor, uint16_t frs_type, uint32_t *words,
+                  uint16_t num_words);
+uint8_t erase_FRS(sensor_meta *sensor, uint16_t frs_type);
 
 // Private function exposed for unit testing:
 #ifdef BNO085_BUILD_FOR_INTERNAL_UNIT_TESTS

--- a/include/BNO085_SPI_Library.h
+++ b/include/BNO085_SPI_Library.h
@@ -91,6 +91,8 @@ uint8_t get_ME_Calibration_Config_IMU(sensor_meta *sensor);
 uint8_t config_periodic_DCD_IMU(sensor_meta *sensor, bool enable_periodic_DCD);
 uint8_t check_Command_Success(sensor_meta *sensor, uint8_t status_command);
 void deassert_csn(sensor_meta *sensor);
+uint8_t read_FRS(sensor_meta *sensor, uint16_t frs_type, uint32_t *buffer,
+                 uint16_t max_words, uint16_t *words_read);
 
 // Private function exposed for unit testing:
 #ifdef BNO085_BUILD_FOR_INTERNAL_UNIT_TESTS

--- a/src/BNO085_SPI_Library.c
+++ b/src/BNO085_SPI_Library.c
@@ -2084,6 +2084,7 @@ uint8_t read_FRS(sensor_meta *sensor, uint16_t frs_type, uint32_t *buffer,
                  uint16_t max_words, uint16_t *words_read) {
   uint8_t status = N_ERR;
   uint16_t offset = 0;
+  uint16_t timeout_counter = 0;
 
   *words_read = 0;  // initialize
 
@@ -2105,6 +2106,11 @@ uint8_t read_FRS(sensor_meta *sensor, uint16_t frs_type, uint32_t *buffer,
   while (!done) {
     status &= check_Command_Success(sensor, status);
     if (status == D_ERR) return D_ERR;
+
+    // Timeout protection
+    if (++timeout_counter >= 1000) {
+      return D_ERR;  // timed out waiting for response
+    }
 
     // Check if this is a read response
     if (sensor->shtp_package.shtp_Data[0] != SHTP_REPORT_FRS_READ_RESPONSE) {

--- a/src/BNO085_SPI_Library.c
+++ b/src/BNO085_SPI_Library.c
@@ -2091,6 +2091,7 @@ uint8_t read_FRS(sensor_meta *sensor, uint16_t frs_type, uint32_t *buffer,
   uint8_t status = N_ERR;
   uint16_t timeout_counter = 0;
   *words_read = 0;
+  int16_t last_offset = -2;
 
   // Send FRS Read Request
   sensor->shtp_package.shtp_Data[0] = SHTP_REPORT_FRS_READ_REQUEST;  // 0xF4
@@ -2132,6 +2133,11 @@ uint8_t read_FRS(sensor_meta *sensor, uint16_t frs_type, uint32_t *buffer,
       break;
     }
 
+    if (offset != (last_offset + 2)) {
+      // Missed packet
+      return D_ERR;
+    }
+
     if (frs_status == 0 || frs_status == 3) {
       // Copy words into buffer
       for (uint8_t i = 0; i < num_words; i++) {
@@ -2143,6 +2149,7 @@ uint8_t read_FRS(sensor_meta *sensor, uint16_t frs_type, uint32_t *buffer,
             (sensor->shtp_package.shtp_Data[data_index + 3] << 24);
       }
       *words_read += num_words;
+      last_offset = offset;
 
       if (frs_status == 3) {
         // Completed

--- a/src/BNO085_SPI_Library.c
+++ b/src/BNO085_SPI_Library.c
@@ -2089,7 +2089,6 @@ void deassert_csn(sensor_meta *sensor) { csn(sensor->ports_pins, true); }
 uint8_t read_FRS(sensor_meta *sensor, uint16_t frs_type, uint32_t *buffer,
                  uint16_t max_words, uint16_t *words_read) {
   uint8_t status = N_ERR;
-  uint16_t offset = 0;
   uint16_t timeout_counter = 0;
   *words_read = 0;
 
@@ -2129,7 +2128,7 @@ uint8_t read_FRS(sensor_meta *sensor, uint16_t frs_type, uint32_t *buffer,
 
     if (frs_status == 5) {
       // Record empty → valid, but no data
-      words_read = 0;
+      *words_read = 0;
       break;
     }
 
@@ -2143,7 +2142,7 @@ uint8_t read_FRS(sensor_meta *sensor, uint16_t frs_type, uint32_t *buffer,
             (sensor->shtp_package.shtp_Data[data_index + 2] << 16) |
             (sensor->shtp_package.shtp_Data[data_index + 3] << 24);
       }
-      words_read += num_words;
+      *words_read += num_words;
 
       if (frs_status == 3) {
         // Completed


### PR DESCRIPTION
FRS read and write functions are useful to better understand the calibration behavior of the BNO08x. Currently, only the read function works.
The write function encounters a problem after the data is sent. The sensor responds with "write mode entered" after the write request is sent, but returns "data received while not in write mode" when the data is sent. I'm still working on figuring out what's going wrong.