### PR TITLE
Store sensor reset reason

### DIFF
--- a/include/BNO085_SPI_Library.h
+++ b/include/BNO085_SPI_Library.h
@@ -76,6 +76,7 @@ uint8_t get_StabilityClassifier(sensor_meta *sensor);
 void update_TapDetector(sensor_meta *sensor);
 uint8_t get_ProductID(sensor_meta *sensor);
 uint8_t get_Reset_Reason(sensor_meta *sensor);
+const char* get_Reset_Reason_String(uint8_t reset_reason);
 uint8_t check_Connection_IMU(sensor_meta *sensor);
 uint8_t tare_IMU(sensor_meta *sensor, bool all_Axis);
 uint8_t tare_persist_IMU(sensor_meta *sensor);

--- a/include/Sensor_Struct.h
+++ b/include/Sensor_Struct.h
@@ -24,6 +24,14 @@
 // There are 6 command channels.
 #define CHANNEL_MAX_NUMBER 6
 
+// Reset reason constants (cf. SH-2 Reference Manual, p.40, Product ID Response)
+#define RESET_REASON_NOT_APPLICABLE 0    // Not applicable
+#define RESET_REASON_POWER_ON 1          // Power on reset
+#define RESET_REASON_INTERNAL_SYSTEM 2   // Internal system reset
+#define RESET_REASON_WATCHDOG_TIMEOUT 3  // Watchdog timeout
+#define RESET_REASON_EXTERNAL_RESET 4    // External reset
+#define RESET_REASON_OTHER 5             // Other
+
 // --- Sensor structs -------------------------------------------------
 // Struct for ports and pins of sensor
 typedef struct ports_pins {

--- a/src/BNO085_SPI_Library.c
+++ b/src/BNO085_SPI_Library.c
@@ -1557,6 +1557,30 @@ uint8_t get_Reset_Reason(sensor_meta *sensor) {
 }
 
 /**
+ * @brief Returns a human-readable string for the reset reason code.
+ * @param reset_reason: Reset reason code from sensor->reset_reason
+ * @return: Pointer to constant string describing the reset reason
+ */
+const char* get_Reset_Reason_String(uint8_t reset_reason) {
+  switch (reset_reason) {
+    case RESET_REASON_NOT_APPLICABLE:
+      return "Not applicable";
+    case RESET_REASON_POWER_ON:
+      return "Power on reset";
+    case RESET_REASON_INTERNAL_SYSTEM:
+      return "Internal system reset";
+    case RESET_REASON_WATCHDOG_TIMEOUT:
+      return "Watchdog timeout";
+    case RESET_REASON_EXTERNAL_RESET:
+      return "External reset";
+    case RESET_REASON_OTHER:
+      return "Other";
+    default:
+      return "Unknown reset reason";
+  }
+}
+
+/**
  * @brief Checks the connection of IMU via Product ID Request and Response.
  * @param *sensor: Pointer to corresponding sensor meta data
  * @return: status, 1 no error occurred, 0 error occurred

--- a/src/BNO085_SPI_Library.c
+++ b/src/BNO085_SPI_Library.c
@@ -1490,6 +1490,8 @@ uint8_t get_ProductID(sensor_meta *sensor) {
   if (status == N_ERR) {
     if (sensor->shtp_package.shtp_Data[0] == SHTP_REPORT_PRODUCT_ID_RESPONSE) {
       // Store product id response (cf. [2], p. 39 f.)
+      // Get reset reason (byte 1)
+      sensor->reset_reason = sensor->shtp_package.shtp_Data[1];
       // Get SW Version Major (byte 2)
       sensor->info.SW_Version_Major = sensor->shtp_package.shtp_Data[2];
       // Get SW Version Minor (byte 3)


### PR DESCRIPTION
We store the sensor reset reason. The data structure already had a field for it.